### PR TITLE
push base setting upon init

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,9 @@ var SaaSquatch = module.exports = integration('SaaSquatch')
 
 SaaSquatch.prototype.initialize = function() {
   window._sqh = window._sqh || [];
+  window._sqh.push(['init', {
+    tenant_alias: this.options.tenantAlias
+  }]);
   this.load(this.ready);
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -34,6 +34,23 @@ describe('SaaSquatch', function() {
       .global('_sqh'));
   });
 
+  describe('before loading', function() {
+    beforeEach(function() {
+      analytics.stub(saasquatch, 'load');
+      analytics.initialize();
+    });
+
+    it('should create window._sqh', function() {
+      analytics.assert(window._sqh instanceof Array);
+    });
+
+    it('should push init onto window._sqh upon initialization', function() {
+      analytics.deepEqual(window._sqh[0], ['init', {
+        tenant_alias: options.tenantAlias
+      }]);
+    });
+  });
+
   describe('loading', function() {
     it('should load', function(done) {
       analytics.on('ready', done);


### PR DESCRIPTION
This fixes #3 

According to SQ [docs](http://docs.referralsaasquatch.com/squatchjs/#init), 

![](https://cloudup.com/cbOU9bwk90f+)

This should be the bare minimum option that the library should be initialized with. The user info can be pushed later with `.identify()` calls. Without this, there will be an error in the console upon init because it's looking for the `init` method in the queue. 

@segment-integrations/core 
