### PR TITLE
Fix payment_provider_id null behavior

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -91,6 +91,10 @@ SaaSquatch.prototype.identify = function(identify) {
     }
   }
 
+  if (init.payment_provider_id === 'null') {
+    init.payment_provider_id = null;
+  }
+
   var image = objCase.find(opts, 'referralImage') || objCase.find(init, 'referralImage') || this.options.referralImage;
   if (image) {
     objCase.del(init, 'referralImage');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -161,6 +161,19 @@ describe('SaaSquatch', function() {
         }]);
       });
 
+      it('should null out paymentProviderId when passed "null"', function() {
+        analytics.identify({ email: 'self@example.com' }, { SaaSquatch: { paymentProviderId: 'null' } });
+        analytics.called(window._sqh.push, ['init', {
+          user_id: null,
+          tenant_alias: 'baz',
+          email: 'self@example.com',
+          first_name: undefined,
+          last_name: undefined,
+          user_image: undefined,
+          payment_provider_id: null
+        }]);
+      });
+
       it('should pass accountStatus', function() {
         analytics.identify({ email: 'self@example.com' }, { SaaSquatch: { accountStatus: 'active' } });
         analytics.called(window._sqh.push, ['init', {


### PR DESCRIPTION
SaaSquatch behaves differently when `payment_provider_id` is explicitly `null`, rather than omitted. This restores a previous behavior where the user could pass the string `'null'` and we would replace it with a `null`.
